### PR TITLE
Allow cfn_response to be called inside handler

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@ your AWS Lambda function.
 
     from cfnlambda import handler_decorator
 
-    @handler_decorator()
+    @handler_decorator
     def lambda_handler(event, context):
         sum = (float(event['ResourceProperties']['key1']) + 
                float(event['ResourceProperties']['key2']))
@@ -104,7 +104,7 @@ First, this Lambda code must be zipped and uploaded to an s3 bucket.
     import logging
     logging.getLogger().setLevel(logging.INFO)
 
-    @handler_decorator()
+    @handler_decorator
     def lambda_handler(event, context):
         sum = (float(event['ResourceProperties']['key1']) + 
                float(event['ResourceProperties']['key2']))
@@ -123,7 +123,7 @@ Here are a set of commands to create and upload the AWS Lambda function
     import logging
     logging.getLogger().setLevel(logging.INFO)
 
-    @handler_decorator()
+    @handler_decorator
     def lambda_handler(event, context):
         sum = (float(event['ResourceProperties']['key1']) + 
                float(event['ResourceProperties']['key2']))
@@ -300,22 +300,3 @@ the search bar. You should get back a single user's profile which lists out a
 collection of accounts that the user has proved control of. A strong indicator
 that the person is the author is if you can find `cfnlambda` in their github
 account.
-
-FAQ
----
-
-Q: What causes the error `inner_decorator() takes exactly 1 argument (2 given): TypeError Traceback
-(most recent call last): File "/var/runtime/awslambda/bootstrap.py", line
-177, in handle_event_request result = request_handler(json_input, context)
-TypeError: inner_decorator() takes exactly 1 argument (2 given)`
-
-A: You likely used `@handler_decorator` to decorate your function instead of
-`@handler_decorator()`. Because `handler_decorator` accepts arguments, you need
-to use it with parenthesis. 
-
-.. _AWS CLI: http://docs.aws.amazon.com/cli/latest/reference/s3/index.html
-.. _install and configure AWS CLI: http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-set-up.html
-.. _returning: https://docs.python.org/2/reference/simple_stmts.html#return
-.. _cfn-response: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-lambda-function-code.html#cfn-lambda-function-code-cfnresponsemodule
-.. _downloads section on PyPI: https://pypi.python.org/pypi/cfnlambda#downloads
-.. _keybase: https://keybase.io/

--- a/cfnlambda.py
+++ b/cfnlambda.py
@@ -136,13 +136,18 @@ def cfn_response(event,
         logger.debug(traceback.format_exc())
 
 
-def handler_decorator(delete_logs=True,
-                      hide_stack_delete_failure=True):
+def handler_decorator(*args, **kwargs):
     """Decorate an AWS Lambda function to add exception handling, emit
     CloudFormation responses and log.
 
     Usage:
-        >>> @handler_decorator()
+        >>> @handler_decorator
+        ... def lambda_handler(event, context):
+        ...     sum = (float(event['ResourceProperties']['key1']) +
+        ...            float(event['ResourceProperties']['key2']))
+        ...     return {'sum': sum}
+
+        >>> @handler_decorator(delete_logs=False)
         ... def lambda_handler(event, context):
         ...     sum = (float(event['ResourceProperties']['key1']) +
         ...            float(event['ResourceProperties']['key2']))
@@ -169,6 +174,11 @@ def handler_decorator(delete_logs=True,
     Raises:
         No exceptions
     """
+    if args:
+        return handler_decorator()(args[0])
+
+    delete_logs = kwargs.get('delete_logs', True)
+    hide_stack_delete_failure = kwargs.get('hide_stack_delete_failure', True)
 
     def inner_decorator(handler):
         """Bind handler_decorator to handler_wrapper in order to enable passing

--- a/cfnlambda.py
+++ b/cfnlambda.py
@@ -305,8 +305,9 @@ def handler_decorator(*args, **kwargs):
                 if status.isSuccess() and delete_logs:
                     logging.disable(logging.CRITICAL)
                     logs_client = boto3.client('logs')
-                    logs_client.delete_log_group(
-                        logGroupName=context.log_group_name)
+                    logs_client.delete_log_stream(
+                        logGroupName=context.log_group_name,
+                        logStreamName=context.log_stream_name)
             result = (dict(result) if isinstance(result, dict) else {'result': result})
             if not status.isFinished():
                 cfn_response(event,

--- a/cfnlambda.py
+++ b/cfnlambda.py
@@ -19,6 +19,7 @@ import json
 from functools import wraps
 import boto3
 from botocore.vendored import requests
+import traceback
 
 logger = logging.getLogger(__name__)
 
@@ -221,6 +222,7 @@ def handler_decorator(delete_logs=True,
                            (handler.__name__, e.message))
                 result = {'result': message}
                 logger.error(message)
+                logger.debug(traceback.format_exc())
 
             if event['RequestType'] == RequestType.DELETE:
                 if status == Status.FAILED and hide_stack_delete_failure:


### PR DESCRIPTION
If the handler knows the physical resource ID, it has to call `cfn_response` itself. I've made `Status` more complex to allow the following workflow (while allowing backwards compatibility):

``` python
@handler_decorator()
def handler(event, context):
    valid = validate(event)
    if not valid:
        return Status.getFailed('event failed validation')
    try:
        success, physical_resource_id, data = handler_logic(event)
    except Exception, e:
        return Status.getFailed(str(e))

    status = Status.SUCCESS if success else Status.getFailed('failed')
    resp = cfn_response(event, context, status, 
            physical_resource_id=physical_resource_id, response_data=data)
    # optionally do something with response object

    return Status.getFinished(status) # wrapper still takes care of cleanup based on status
```

The new status can also be used without calling `cfn_response` in the handler:

``` python
@handler_decorator()
def handler(event, context):
    valid = validate(event)
    if not valid:
        return Status.getFailed('event failed validation')
    try:
        success, physical_resource_id, data = handler_logic(event)
    except Exception, e:
        return Status.getFailed(str(e))

    status = Status.SUCCESS if success else Status.getFailed('failed')
    return status, data # wrapper calls cfn_response
```

I also made `handler_decorator` work when it's used without parentheses.
